### PR TITLE
Feat/message list cloak

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,11 +20,6 @@ repos:
         entry: ruff format .
         language: python
         types: [python]
-      - id: build
-        name: Build the LLMShield Package
-        entry: make build
-        language: python
-        types: [python]
       - id: check-coverage
         name: Check Test Coverage
         entry: make coverage

--- a/llmshield/cloak_prompt.py
+++ b/llmshield/cloak_prompt.py
@@ -31,6 +31,8 @@ def _cloak_prompt(
 
     # Create a reverse map for quick lookups of existing values
     reversed_entity_map = {v: k for k, v in entity_map.items()}
+    if len(entity_map.keys()) > 0:
+        print("Cached Reverse entity map", reversed_entity_map)
 
     detector = EntityDetector()
     entities: set[Entity] = detector.detect_entities(prompt)

--- a/llmshield/entity_detector.py
+++ b/llmshield/entity_detector.py
@@ -126,26 +126,20 @@ class EntityDetector:
     @staticmethod
     def _load_cities() -> list[str]:
         """Load cities from lists/cities.txt."""
-        with resources.files(
-            "llmshield.matchers.dicts"
-        ).joinpath("cities.txt").open("r") as f:
+        with resources.files("llmshield.matchers.dicts").joinpath("cities.txt").open("r") as f:
             return [city.strip() for city in f.read().splitlines() if city.strip()]
 
     @staticmethod
     def _load_countries() -> list[str]:
         """Load countries from lists/countries.txt."""
-        with resources.files(
-            "llmshield.matchers.dicts"
-        ).joinpath("countries.txt").open("r") as f:
+        with resources.files("llmshield.matchers.dicts").joinpath("countries.txt").open("r") as f:
             return [c.strip() for c in f.read().splitlines() if c.strip()]
 
     @staticmethod
     def _load_organisations() -> list[str]:
         """Load organisations from lists/organisations.txt."""
         with (
-            resources.files(
-                "llmshield.matchers.dicts"
-            ).joinpath("organisations.txt").open("r") as f
+            resources.files("llmshield.matchers.dicts").joinpath("organisations.txt").open("r") as f
         ):
             return [org.strip() for org in f.read().splitlines() if org.strip()]
 
@@ -236,12 +230,9 @@ class EntityDetector:
                 is_capitalised = word and word[0].isupper()
 
                 if is_honorific or (
-                    not any(c in word for c in self.en_punctuation if c != ".")
-                    and is_capitalised
+                    not any(c in word for c in self.en_punctuation if c != ".") and is_capitalised
                 ):
-                    pending_p_noun = (
-                        pending_p_noun + SPACE + word if pending_p_noun else word
-                    )
+                    pending_p_noun = pending_p_noun + SPACE + word if pending_p_noun else word
                 elif pending_p_noun:
                     sequential_pnouns.append(pending_p_noun.strip())
                     pending_p_noun = ""

--- a/llmshield/lru_cache.py
+++ b/llmshield/lru_cache.py
@@ -1,0 +1,47 @@
+from collections import OrderedDict
+from typing import Generic, TypeVar
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class LRUCache(Generic[K, V]):
+    """A simple LRU (Least Recently Used) cache implementation using OrderedDict.
+
+    Taken directly from: https://llego.dev/posts/implement-lru-cache-python/
+    """
+
+    def __init__(self, capacity: int) -> None:
+        """Initializes the LRUCache with a specific capacity.
+
+        Args:
+            capacity (int): The maximum number of items the cache can hold before eviction.
+        """
+        self.cache: OrderedDict[K, V] = OrderedDict()
+        self.capacity = capacity
+
+    def get(self, key: K) -> V | None:
+        """Retrieves an item from the cache.
+
+        Args:
+            key (K): The key of the item to retrieve.
+
+        Returns:
+            V | None: The value associated with the key, or None if not found.
+        """
+        if key not in self.cache:
+            return None
+        self.cache.move_to_end(key)
+        return self.cache[key]
+
+    def put(self, key: K, value: V) -> None:
+        """Adds an item to the cache.
+
+        Args:
+            key (K): The key of the item to add.
+            value (V): The value of the item to add.
+        """
+        self.cache[key] = value
+        self.cache.move_to_end(key)
+        if len(self.cache) > self.capacity:
+            self.cache.popitem(last=False)

--- a/llmshield/utils.py
+++ b/llmshield/utils.py
@@ -173,3 +173,22 @@ def ask_helper(shield, stream: bool, **kwargs) -> str | Generator[str, None, Non
         # Non-streaming: uncloak complete response
         return shield.uncloak(llm_response, entity_map)
     return shield.llm_func(**kwargs)  # No cloaking needed, call LLM directly
+
+
+# Typedef for a hashable type used for conversation keys.
+type Hash = int
+type Message = dict[str, str]
+
+
+def conversation_hash(obj: Message | list[Message]) -> Hash:
+    """
+    Generate a stable, hashable key for a message or a list of messages.
+    If a single message is provided, hash its role and content.
+    If a list of messages is provided, hash the set of (role, content) pairs.
+    """
+    if isinstance(obj, dict):
+        # Single message
+        return hash((obj.get("role", ""), obj.get("content", "")))
+
+    # List of messages
+    return hash(frozenset((msg.get("role", ""), msg.get("content", "")) for msg in obj))

--- a/tests/test_lru_cache.py
+++ b/tests/test_lru_cache.py
@@ -1,0 +1,74 @@
+from unittest import TestCase, main
+
+from llmshield.lru_cache import LRUCache
+
+
+class TestLRUCache(TestCase):
+    """Tests for the LRUCache implementation."""
+
+    def test_init(self):
+        """Test cache initialization."""
+        cache: LRUCache[str, int] = LRUCache(capacity=3)
+        self.assertEqual(cache.capacity, 3)
+        self.assertEqual(len(cache.cache), 0)
+
+    def test_put_and_get(self):
+        """Test basic put and get operations."""
+        cache: LRUCache[str, int] = LRUCache(capacity=2)
+        cache.put("a", 1)
+        cache.put("b", 2)
+        self.assertEqual(cache.get("a"), 1)
+        self.assertEqual(cache.get("b"), 2)
+        self.assertEqual(len(cache.cache), 2)
+
+    def test_get_nonexistent_key(self):
+        """Test getting a non-existent key returns None."""
+        cache: LRUCache[str, int] = LRUCache(capacity=2)
+        cache.put("a", 1)
+        self.assertIsNone(cache.get("b"))
+
+    def test_lru_eviction(self):
+        """Test that the least recently used item is evicted."""
+        cache: LRUCache[str, int] = LRUCache(capacity=2)
+        cache.put("a", 1)
+        cache.put("b", 2)
+        cache.put("c", 3)  # This should evict "a"
+        self.assertIsNone(cache.get("a"))
+        self.assertEqual(cache.get("b"), 2)
+        self.assertEqual(cache.get("c"), 3)
+        self.assertEqual(len(cache.cache), 2)
+
+    def test_get_updates_recency(self):
+        """Test that getting an item makes it the most recently used."""
+        cache: LRUCache[str, int] = LRUCache(capacity=2)
+        cache.put("a", 1)
+        cache.put("b", 2)
+        cache.get("a")  # "a" is now the most recently used
+        cache.put("c", 3)  # This should evict "b"
+        self.assertIsNone(cache.get("b"))
+        self.assertEqual(cache.get("a"), 1)
+        self.assertEqual(cache.get("c"), 3)
+
+    def test_put_updates_existing_key(self):
+        """Test that putting an existing key updates the value and recency."""
+        cache: LRUCache[str, int] = LRUCache(capacity=2)
+        cache.put("a", 1)
+        cache.put("b", 2)
+        cache.put("a", 100)  # Update "a"
+        cache.put("c", 3)  # This should evict "b"
+        self.assertIsNone(cache.get("b"))
+        self.assertEqual(cache.get("a"), 100)
+        self.assertEqual(cache.get("c"), 3)
+
+    def test_capacity_one(self):
+        """Test edge case with capacity of 1."""
+        cache: LRUCache[str, int] = LRUCache(capacity=1)
+        cache.put("a", 1)
+        self.assertEqual(cache.get("a"), 1)
+        cache.put("b", 2)
+        self.assertIsNone(cache.get("a"))
+        self.assertEqual(cache.get("b"), 2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces significant enhancements to the `llmshield` package, focusing on improving the handling of sensitive information in multi-turn conversations, adding caching mechanisms, and simplifying code logic. Key changes include the addition of an LRU cache for entity maps, updates to the `cloak` and `ask` methods to support multi-turn conversations, and the introduction of helper functions for hashing conversation histories.

### Enhancements to multi-turn conversation handling:
* [`llmshield/core.py`](diffhunk://#diff-1f42f15de4698bba53d4f27d5eb6674501a4280550d7306a19c751b482fd4658L237-L247): Updated the `ask` method to support multi-turn conversations by introducing a `messages` parameter. Added logic to cache entity maps for conversation histories using the new `LRUCache` class and implemented cloaking/uncloaking for multi-turn interactions. [[1]](diffhunk://#diff-1f42f15de4698bba53d4f27d5eb6674501a4280550d7306a19c751b482fd4658L237-L247) [[2]](diffhunk://#diff-1f42f15de4698bba53d4f27d5eb6674501a4280550d7306a19c751b482fd4658L304-R379)
* [`llmshield/utils.py`](diffhunk://#diff-185320b5ee1febabb2e4935a008cde4f14c3416006cfe0c5d26353a719f1e83eR176-R194): Added the `conversation_hash` function to generate stable hashable keys for conversation histories, enabling efficient caching.

### Caching improvements:
* [`llmshield/lru_cache.py`](diffhunk://#diff-21eb88db508aab97c0c4f2cf9dbe321b6e54495933f0d008ebdc47c41b1c8432R1-R47): Added a new `LRUCache` class to manage entity map caching, ensuring efficient retrieval and eviction of cached items.
* [`llmshield/core.py`](diffhunk://#diff-1f42f15de4698bba53d4f27d5eb6674501a4280550d7306a19c751b482fd4658R113-R119): Integrated the `LRUCache` into the `LLMShield` class to store entity maps for multi-turn conversations.

### Updates to cloaking logic:
* [`llmshield/cloak_prompt.py`](diffhunk://#diff-90263e4488f4949ed13c0dc13ce9e95504eeb8fceadd32d86140ca1704a7bbb6R9-L41): Enhanced the `_cloak_prompt` function to accept an existing `entity_map` for maintaining placeholder consistency across multi-turn conversations. Simplified the logic for generating placeholders and handling matches.

### Code cleanup and type annotations:
* [`llmshield/entity_detector.py`](diffhunk://#diff-b8aa17446cf959d99e670e6debab5de650717ee70f2bc0352339065002b73f17L129-R142): Simplified file handling logic for loading cities, countries, and organizations. Cleaned up conditional formatting in `_collect_proper_nouns`. [[1]](diffhunk://#diff-b8aa17446cf959d99e670e6debab5de650717ee70f2bc0352339065002b73f17L129-R142) [[2]](diffhunk://#diff-b8aa17446cf959d99e670e6debab5de650717ee70f2bc0352339065002b73f17L239-R235)
* [`llmshield/core.py`](diffhunk://#diff-1f42f15de4698bba53d4f27d5eb6674501a4280550d7306a19c751b482fd4658L33-R43): Added type hints and `# type: ignore` comments to suppress warnings for certain imports and method signatures. [[1]](diffhunk://#diff-1f42f15de4698bba53d4f27d5eb6674501a4280550d7306a19c751b482fd4658L33-R43) [[2]](diffhunk://#diff-1f42f15de4698bba53d4f27d5eb6674501a4280550d7306a19c751b482fd4658L161-R171)

### Test updates:
* [`tests/test_core.py`](diffhunk://#diff-938de46e643ab091cff6a7c23e4e752e8907e2266f47889d988923352f7a1058L14-R14): Added `conversation_hash` to the test imports to validate new functionality.